### PR TITLE
Add Tkinter GUI wrapper for existing converter script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ sh converter.sh input ouput mp3
 ```
 Notice: the `input` folder is content the audio files you need to convert, the `output` folder is content the audio files after conversion finished, the `mp3` is a format you need to output.
 
+A simple Tkinter interface is available via `gui.py` which internally
+invokes `converter.sh` for the actual conversion.  Run it with:
+```bash
+python gui.py
+```
+
 If you need to convert files on the `Windows` platfrom, [click here](https://dl.kn007.net/directlink/silk2mp3.zip "silk2mp3.zip") to download zip package for `silk2mp3.exe` to convert, also can <a href='/windows' target="_blank">click here</a> to get more information.
 
 ## Other
@@ -97,6 +103,12 @@ sh converter.sh 33921FF3774A773BB193B6FD4AD7C33E.slk mp3
 sh converter.sh input ouput mp3
 ```
 注意：其中`input`是要转换的目录，而`output`是最终转换后音频输出的目录，最后的`mp3`参数是最终转换后输出的格式。
+
+项目还提供 `gui.py` 脚本，通过 Tkinter 图形界面调用 `converter.sh`
+实现转换，运行方式如下：
+```bash
+python gui.py
+```
 
 如果你需要在`Windows`下使用该程序，请下载[silk2mp3.exe](https://dl.kn007.net/directlink/silk2mp3.zip "silk2mp3.zip")应用程序来完成转换，你可<a href='/windows' target="_blank">点击这里</a>来查看更多Windows下如何使用的相关说明。
 

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,86 @@
+import os
+import subprocess
+import sys
+from tkinter import Tk, filedialog, messagebox, ttk
+from tkinter import StringVar, BooleanVar, Label, Entry, Button, Checkbutton
+
+
+class SilkGUI:
+    def __init__(self, master):
+        self.master = master
+        master.title("Silk Converter")
+
+        self.input_path = StringVar()
+        self.output_dir = StringVar()
+        self.format_var = StringVar(value="mp3")
+        self.batch_var = BooleanVar(value=False)
+
+        Label(master, text="Input file or folder:").grid(row=0, column=0, sticky="w")
+        Entry(master, textvariable=self.input_path, width=50).grid(row=0, column=1, padx=5)
+        Button(master, text="Browse", command=self.browse_input).grid(row=0, column=2)
+
+        Checkbutton(master, text="Batch mode (folder)", variable=self.batch_var).grid(row=1, column=1, sticky="w")
+
+        Label(master, text="Output directory:").grid(row=2, column=0, sticky="w")
+        Entry(master, textvariable=self.output_dir, width=50).grid(row=2, column=1, padx=5)
+        Button(master, text="Browse", command=self.browse_output).grid(row=2, column=2)
+
+        Label(master, text="Output format:").grid(row=3, column=0, sticky="w")
+        format_cb = ttk.Combobox(master, textvariable=self.format_var,
+                                 values=["mp3", "wav", "ogg"], width=10, state="readonly")
+        format_cb.grid(row=3, column=1, sticky="w")
+
+        Button(master, text="Start", command=self.start).grid(row=4, column=1, pady=5)
+
+    def browse_input(self):
+        if self.batch_var.get():
+            path = filedialog.askdirectory()
+        else:
+            path = filedialog.askopenfilename()
+        if path:
+            self.input_path.set(path)
+
+    def browse_output(self):
+        path = filedialog.askdirectory()
+        if path:
+            self.output_dir.set(path)
+
+    def start(self):
+        in_path = self.input_path.get()
+        out_dir = self.output_dir.get()
+        out_fmt = self.format_var.get()
+        batch = self.batch_var.get()
+
+        if not in_path:
+            messagebox.showerror("Error", "Please select input path")
+            return
+
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        script = os.path.join(script_dir, "converter.sh")
+        if not os.path.isfile(script):
+            messagebox.showerror("Error", f"converter.sh not found: {script}")
+            return
+
+        if batch:
+            if not out_dir:
+                messagebox.showerror("Error", "Please select output directory")
+                return
+            cmd = ["bash", script, in_path, out_dir, out_fmt]
+        else:
+            cmd = ["bash", script, in_path, out_fmt]
+
+        try:
+            subprocess.check_call(cmd)
+            messagebox.showinfo("Done", "Conversion finished")
+        except subprocess.CalledProcessError:
+            messagebox.showerror("Error", "Conversion failed")
+
+
+def main():
+    root = Tk()
+    SilkGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `gui.py` providing a simple Tkinter front‑end that calls `converter.sh`
- document how to launch the GUI in both English and Chinese sections of `README.md`

## Testing
- `python3 -m py_compile gui.py`
- `python3 gui.py` *(fails: no $DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_684249e2c48883278f70daee792f1999